### PR TITLE
Simplify agent model names to use short aliases

### DIFF
--- a/.claude/agents/architect-reviewer.agent.md
+++ b/.claude/agents/architect-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: architect-reviewer
 description: アーキテクチャ設計書が要件を満たし Clean Architecture に準拠しているか、UI 仕様書との整合性を含めてレビューします。architect・ui-designer が完了した後に呼び出してください。
-model: claude-opus-4-7
+model: opus
 tools:
   - Read
   - Grep

--- a/.claude/agents/architect.agent.md
+++ b/.claude/agents/architect.agent.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: 要件定義書をもとに Clean Architecture ベースのシステム設計を行い、architecture/ARCHITECTURE.md を作成します。
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/.claude/agents/code-reviewer.agent.md
+++ b/.claude/agents/code-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: 実装コードがアーキテクチャに準拠し、テストが十分であるかをレビューします。implementer が完了した後に呼び出してください。
-model: claude-opus-4-7
+model: opus
 tools:
   - Read
   - Grep

--- a/.claude/agents/implementer.agent.md
+++ b/.claude/agents/implementer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 description: 要件・設計・テスト仕様に従い TDD でコードを実装します。テストを先に書いてから実装します。
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/.claude/agents/requirements-analyst.agent.md
+++ b/.claude/agents/requirements-analyst.agent.md
@@ -1,7 +1,7 @@
 ---
 name: requirements-analyst
 description: ユーザーヒアリングを通じて要件を洗い出し、requirement/REQUIREMENTS.md を作成します。要件定義フェーズで呼び出してください。
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/.claude/agents/requirements-reviewer.agent.md
+++ b/.claude/agents/requirements-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: requirements-reviewer
 description: 要件定義書の抜け漏れ・実現可能性・テスト設計への移行準備をレビューします。requirements-analyst が完了した後に呼び出してください。
-model: claude-opus-4-7
+model: opus
 tools:
   - Read
   - Grep

--- a/.claude/agents/test-designer.agent.md
+++ b/.claude/agents/test-designer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: test-designer
 description: 要件定義書をもとにテストケースを設計し、test/TEST_SPEC.md を作成します。TDD のテスト仕様を担当します。
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/.claude/agents/test-reviewer.agent.md
+++ b/.claude/agents/test-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: test-reviewer
 description: テスト仕様書が要件を十分にカバーし品質基準を満たしているかレビューします。test-designer が完了した後に呼び出してください。
-model: claude-opus-4-7
+model: opus
 tools:
   - Read
   - Grep

--- a/.claude/agents/ui-designer.agent.md
+++ b/.claude/agents/ui-designer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: ui-designer
 description: 要件・アーキテクチャをもとに UI 仕様と画面遷移を設計し、design/UI_SPEC.md を作成します。
-model: claude-sonnet-4-6
+model: sonnet
 tools:
   - Read
   - Write

--- a/.claude/agents/ui-reviewer.agent.md
+++ b/.claude/agents/ui-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: ui-reviewer
 description: UI 仕様書が要件を満たし、画面遷移・入力/出力・メッセージ定義が明確で使いやすいかレビューします。ui-designer が完了した後に呼び出してください。
-model: claude-opus-4-7
+model: opus
 tools:
   - Read
   - Grep


### PR DESCRIPTION
## Summary
Updated all agent configuration files to use simplified model name aliases instead of full model identifiers. This change standardizes the model references across the agent system while maintaining the same underlying model capabilities.

## Key Changes
- **architect-reviewer**: `claude-opus-4-7` → `opus`
- **architect**: `claude-sonnet-4-6` → `sonnet`
- **code-reviewer**: `claude-opus-4-7` → `opus`
- **implementer**: `claude-sonnet-4-6` → `sonnet`
- **requirements-analyst**: `claude-sonnet-4-6` → `sonnet`
- **requirements-reviewer**: `claude-opus-4-7` → `opus`
- **test-designer**: `claude-sonnet-4-6` → `sonnet`
- **test-reviewer**: `claude-opus-4-7` → `opus`
- **ui-designer**: `claude-sonnet-4-6` → `sonnet`
- **ui-reviewer**: `claude-opus-4-7` → `opus`

## Implementation Details
The changes maintain the same agent role assignments:
- **Reviewer agents** (architect-reviewer, code-reviewer, requirements-reviewer, test-reviewer, ui-reviewer) continue to use the `opus` model for comprehensive analysis
- **Creator agents** (architect, implementer, requirements-analyst, test-designer, ui-designer) continue to use the `sonnet` model for efficient content generation

This refactoring improves configuration readability and maintainability without altering agent behavior or capabilities.

https://claude.ai/code/session_014HbhLncZpQfuMsaESTgR9H