### PR TITLE
feat: OpenAI Codex CLI の設定仕様に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Claude Code / GitHub Copilot / OpenAI Codex CLI 向けのグローバル設定�
 
 `install.sh` を実行すると `~/.claude/` にルール・エージェント・スキルなどを配置し、あわせて `~/AGENTS.md` も更新する。  
 GitHub Copilot (VS Code) は `~/.claude/` を自動検出するため、両ツールで設定を共有できる。  
-OpenAI Codex CLI はグローバル指示を `~/.codex/AGENTS.md` から読む（`~/AGENTS.md` は参照しない）ため、`install.sh` は `AGENTS.md` を `~/.codex/AGENTS.md` にも配置する。
+OpenAI Codex CLI はグローバル指示を `~/.codex/AGENTS.md` から、スキルを `~/.agents/skills/` から読む（`~/AGENTS.md` と `~/.claude/skills/` は参照しない）ため、`install.sh` は `AGENTS.md` を `~/.codex/AGENTS.md` に、`.claude/skills/` 配下の各スキルを `~/.agents/skills/` にも配置する。
 
 ## 構成
 
@@ -38,12 +38,14 @@ sh install.sh
 - バックアップ後、`~/.claude/` は再作成され、このリポジトリ内の `.claude/` 配下がコピーされる
 - `AGENTS.md` は `~/AGENTS.md` にコピーされる
 - `AGENTS.md` は Codex 用に `~/.codex/AGENTS.md` にもコピーされる（既存があればバックアップ。`~/.codex/` 内の `config.toml` や `auth.json` は削除・変更しない）
+- `.claude/skills/` 配下の各スキルは Codex 用に `~/.agents/skills/` にもコピーされる（`~/.agents/skills/` 全体はバックアップされるが削除はされず、このリポジトリと同名のスキルのみ置き換える）
 
 インストール後の主な配置先は以下のとおり。
 
 ```text
 ~/AGENTS.md
 ~/.codex/AGENTS.md
+~/.agents/skills/
 ~/.claude/CLAUDE.md
 ~/.claude/settings.json
 ~/.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # settings
 
-Claude Code / GitHub Copilot 向けのグローバル設定リポジトリ。
+Claude Code / GitHub Copilot / OpenAI Codex CLI 向けのグローバル設定リポジトリ。
 
 `install.sh` を実行すると `~/.claude/` にルール・エージェント・スキルなどを配置し、あわせて `~/AGENTS.md` も更新する。  
-GitHub Copilot (VS Code) は `~/.claude/` を自動検出するため、両ツールで設定を共有できる。
+GitHub Copilot (VS Code) は `~/.claude/` を自動検出するため、両ツールで設定を共有できる。  
+OpenAI Codex CLI はグローバル指示を `~/.codex/AGENTS.md` から読む（`~/AGENTS.md` は参照しない）ため、`install.sh` は `AGENTS.md` を `~/.codex/AGENTS.md` にも配置する。
 
 ## 構成
 
@@ -36,11 +37,13 @@ sh install.sh
 - 既存の `~/.claude/` はタイムスタンプ付きで `~/.settings-backup/` にバックアップされる
 - バックアップ後、`~/.claude/` は再作成され、このリポジトリ内の `.claude/` 配下がコピーされる
 - `AGENTS.md` は `~/AGENTS.md` にコピーされる
+- `AGENTS.md` は Codex 用に `~/.codex/AGENTS.md` にもコピーされる（既存があればバックアップ。`~/.codex/` 内の `config.toml` や `auth.json` は削除・変更しない）
 
 インストール後の主な配置先は以下のとおり。
 
 ```text
 ~/AGENTS.md
+~/.codex/AGENTS.md
 ~/.claude/CLAUDE.md
 ~/.claude/settings.json
 ~/.claude/settings.local.json

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ set -eu
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CLAUDE_TARGET="$HOME/.claude"
 CODEX_TARGET="$HOME/.codex"
+AGENTS_SKILLS_TARGET="$HOME/.agents/skills"
 BACKUP_ROOT="$HOME/.settings-backup"
 BACKUP_DIR="$BACKUP_ROOT/$(date +%Y%m%d-%H%M%S)"
 
@@ -53,7 +54,11 @@ mkdir -p "$CLAUDE_TARGET"
 copy_file "$ROOT_DIR/AGENTS.md" "$HOME/AGENTS.md"
 copy_file "$ROOT_DIR/.claude/CLAUDE.md" "$CLAUDE_TARGET/CLAUDE.md"
 copy_file "$ROOT_DIR/.claude/settings.json" "$CLAUDE_TARGET/settings.json"
-copy_file "$ROOT_DIR/.claude/settings.local.json" "$CLAUDE_TARGET/settings.local.json"
+
+# settings.local.json はリポジトリに存在しない場合があるため、存在時のみコピーする
+if [ -f "$ROOT_DIR/.claude/settings.local.json" ]; then
+  copy_file "$ROOT_DIR/.claude/settings.local.json" "$CLAUDE_TARGET/settings.local.json"
+fi
 copy_dir "$ROOT_DIR/.claude/rules" "$CLAUDE_TARGET/rules"
 copy_dir "$ROOT_DIR/.claude/agents" "$CLAUDE_TARGET/agents"
 copy_dir "$ROOT_DIR/.claude/hooks" "$CLAUDE_TARGET/hooks"
@@ -67,3 +72,17 @@ backup_existing "$CODEX_TARGET/AGENTS.md" "codex-AGENTS.md"
 copy_file "$ROOT_DIR/AGENTS.md" "$CODEX_TARGET/AGENTS.md"
 
 printf 'Installed Codex instructions to %s/AGENTS.md\n' "$CODEX_TARGET"
+
+# Codex は Agent Skills を ~/.agents/skills から読む（.agents/skills 規約）。
+# ~/.agents/skills は他ツールと共有され得るため全体は削除せず、
+# このリポジトリと同名のスキルのみバックアップ後に置き換える。
+backup_existing "$AGENTS_SKILLS_TARGET" "agents-skills"
+mkdir -p "$AGENTS_SKILLS_TARGET"
+for skill_dir in "$ROOT_DIR/.claude/skills"/*; do
+  [ -d "$skill_dir" ] || continue
+  skill_name=$(basename -- "$skill_dir")
+  rm -rf "$AGENTS_SKILLS_TARGET/$skill_name"
+  cp -R "$skill_dir" "$AGENTS_SKILLS_TARGET/$skill_name"
+done
+
+printf 'Installed skills to %s\n' "$AGENTS_SKILLS_TARGET"

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CLAUDE_TARGET="$HOME/.claude"
+CODEX_TARGET="$HOME/.codex"
 BACKUP_ROOT="$HOME/.settings-backup"
 BACKUP_DIR="$BACKUP_ROOT/$(date +%Y%m%d-%H%M%S)"
 
@@ -59,3 +60,10 @@ copy_dir "$ROOT_DIR/.claude/hooks" "$CLAUDE_TARGET/hooks"
 copy_dir "$ROOT_DIR/.claude/skills" "$CLAUDE_TARGET/skills"
 
 printf 'Installed settings to %s\n' "$CLAUDE_TARGET"
+
+# OpenAI Codex CLI はグローバル指示を ~/.codex/AGENTS.md から読む（~/AGENTS.md は参照しない）。
+# 認証情報や config.toml を保持する ~/.codex/ は削除せず、AGENTS.md のみ差し替える。
+backup_existing "$CODEX_TARGET/AGENTS.md" "codex-AGENTS.md"
+copy_file "$ROOT_DIR/AGENTS.md" "$CODEX_TARGET/AGENTS.md"
+
+printf 'Installed Codex instructions to %s/AGENTS.md\n' "$CODEX_TARGET"

--- a/knowledge.md
+++ b/knowledge.md
@@ -197,6 +197,7 @@ Instructions とは、AI Agent に守らせたいルールや行動方針を記�
 - **Trust モデル**: プロジェクトスコープの `.codex/`（config・hooks・rules）は、そのプロジェクトが trusted の場合のみロードされる。
 - **プロンプト非推奨**: `~/.codex/prompts/*.md`（トップレベルのみ走査）は slash command として使えるが非推奨。再利用や暗黙呼び出しには Skills（`SKILL.md`）が推奨される。
 - **スキル呼び出し**: `/skills` または `$` でメンション。`description` にタスクが一致すると暗黙的に選択される。同名スキルが複数ロケーションにあるとマージされず両方が候補に出る。
+- **Claude 資産との非互換**: Codex は `.claude/skills/` と `.claude/agents/`（Sub Agent 定義）をロードしない。スキルを Codex でも使うには `~/.agents/skills/` へ配置が必要（本リポジトリでは `install.sh` が同期する）。Sub Agent に相当する仕組みは Codex に無いため、`.claude/agents/` の定義は Claude Code / Copilot 専用となる。
 
 - 参考: [Custom instructions with AGENTS.md – Codex](https://developers.openai.com/codex/guides/agents-md)
 - 参考: [Config basics – Codex](https://developers.openai.com/codex/config-basic)

--- a/knowledge.md
+++ b/knowledge.md
@@ -146,6 +146,64 @@ Instructions とは、AI Agent に守らせたいルールや行動方針を記�
 - Plugin システム: マーケットプレイス経由で skills / agents / hooks / MCP サーバーを配布可能。`/plugin` で管理。
 - 組織全体への Managed CLAUDE.md 配布が可能（MDM経由、`/Library/Application Support/ClaudeCode/CLAUDE.md` 等）。`claudeMd` 設定キーで `managed-settings.json` 内にインラインで記述も可。
 
+### For OpenAI Codex CLI Agent
+
+#### 1. 全PJ共通（ホームディレクトリ）
+
+```text
+~/.codex/                    # CODEX_HOME 環境変数で変更可
+├── config.toml              # ユーザー共通設定（model・approval_policy・sandbox_mode・[mcp_servers] など）
+├── <profile>.config.toml    # プロファイル別設定（--profile <name> で選択）
+├── AGENTS.md                # ユーザー共通の指示（グローバル）
+├── AGENTS.override.md       # AGENTS.md を上書きするグローバル指示（存在すれば優先）
+├── prompts/
+│   └── *.md                 # カスタムプロンプト（/prompts:<名前> で呼び出し。※非推奨、skills 推奨）
+├── hooks.json               # ライフサイクルフック（config.toml 内 [hooks] でも可）
+├── auth.json                # 認証情報（OS キーチェーン利用時は不要）
+└── history.jsonl            # セッション履歴（永続化有効時）
+
+~/.agents/skills/
+└── <skill-name>/SKILL.md    # ユーザー共通スキル（Codex は .agents/skills 規約を参照）
+```
+
+- グローバルな指示は `~/.codex/AGENTS.md` に置く。Copilot / Claude が参照する `~/AGENTS.md` とはパスが別のため、Codex にも同じ指示を効かせるには `~/.codex/AGENTS.md` へ配置する必要がある。
+- スキルは `~/.codex/skills/` ではなく `~/.agents/skills/`（ユーザー）/ `/etc/codex/skills/`（システム）に置く。AGENTS.md エコシステム共通の `.agents/skills` 規約を採用している。
+
+#### 2. PJ固有（プロジェクトルート）
+
+```text
+[project]/
+├── AGENTS.md               # プロジェクト指示（リポジトリルート）
+├── AGENTS.override.md      # AGENTS.md を上書きする指示（存在すれば優先）
+├── .agents/
+│   └── skills/
+│       └── <skill-name>/SKILL.md  # プロジェクトスキル
+└── .codex/
+    ├── config.toml         # プロジェクト固有設定（trusted なPJのみロード）
+    └── hooks.json          # プロジェクト固有フック
+```
+
+- AGENTS.md はリポジトリルートから作業ディレクトリへ向かって各階層で探索され、ルート→下位の順に連結される（下位ディレクトリが優先）。各ディレクトリで採用されるのは1ファイルのみ。
+- サブディレクトリごとに AGENTS.md を置けば、その配下の作業にだけ効く指示を追加できる。探索は作業ディレクトリで止まり、未訪問のサブディレクトリまでは下らない。
+
+#### 3. 重要ポイント（2026-07-08時点）
+
+- **AGENTS.md 解決順**: 各階層で `AGENTS.override.md` → `AGENTS.md` → `project_doc_fallback_filenames` の順に探索し、最初の非空ファイルを採用する。グローバル（`~/.codex/`）でも同じ優先順位。
+- **サイズ上限**: 連結後の指示サイズは `project_doc_max_bytes`（既定 32 KiB）まで。上限到達で以降のファイルは読み込まれない。空ファイルはスキップ。
+- **フォールバック名**: `config.toml` の `project_doc_fallback_filenames`（例 `["TEAM_GUIDE.md", ".agents.md"]`）で AGENTS.md 不在時の代替名を指定できる。
+- **設定の優先順位（高→低）**: ①CLI フラグ / `--config`、②プロジェクト `.codex/config.toml`（ルート→CWD、trusted のみ）、③プロファイル `~/.codex/<name>.config.toml`、④ユーザー `~/.codex/config.toml`、⑤システム `/etc/codex/config.toml`、⑥組み込み既定値。
+- **主な config.toml キー**: `model` / `approval_policy`（`on-request` / `untrusted` / `never`）/ `sandbox_mode`（`workspace-write` など）/ `model_reasoning_effort` / `web_search` / `personality` / `[permissions.<name>]` / `[features]`（`shell_snapshot`、`memories` など）。
+- **MCP**: `config.toml` の `[mcp_servers]` テーブルで設定する（別ファイルではない）。Claude の `.mcp.json` や Copilot の `mcp-config.json` とは形式が異なる。
+- **Trust モデル**: プロジェクトスコープの `.codex/`（config・hooks・rules）は、そのプロジェクトが trusted の場合のみロードされる。
+- **プロンプト非推奨**: `~/.codex/prompts/*.md`（トップレベルのみ走査）は slash command として使えるが非推奨。再利用や暗黙呼び出しには Skills（`SKILL.md`）が推奨される。
+- **スキル呼び出し**: `/skills` または `$` でメンション。`description` にタスクが一致すると暗黙的に選択される。同名スキルが複数ロケーションにあるとマージされず両方が候補に出る。
+
+- 参考: [Custom instructions with AGENTS.md – Codex](https://developers.openai.com/codex/guides/agents-md)
+- 参考: [Config basics – Codex](https://developers.openai.com/codex/config-basic)
+- 参考: [Configuration Reference – Codex](https://developers.openai.com/codex/config-reference)
+- 参考: [Agent Skills – Codex](https://developers.openai.com/codex/skills)
+- 参考: [Custom Prompts – Codex](https://developers.openai.com/codex/custom-prompts)
+
 ## MCP
 
 | 観点 | 内容 |

--- a/knowledge.md
+++ b/knowledge.md
@@ -9,7 +9,7 @@ ChatGPTやGeminiなどのAIが「質問→回答で終わり」なのに対し�
 
 構成要素は LLM（頭脳）・Tools（手足）・Memory（記憶）・Instructions（行動ルール）の4つ。
 
-**本ドキュメントに記載されていることは、2026-5-13時点の情報をもとにしており、今後のアップデートで仕様やベストプラクティスが変わる可能性が高いので、最新情報は公式ドキュメントやコミュニティを参照することを推奨します。**
+**本ドキュメントの各セクションは、見出しや本文に記載した時点（記載のないものは 2026-05-13 時点）の情報をもとにしており、今後のアップデートで仕様やベストプラクティスが変わる可能性が高いので、最新情報は公式ドキュメントやコミュニティを参照することを推奨します。**
 
 ### 各構成要素の概要
 
@@ -155,7 +155,7 @@ Instructions とは、AI Agent に守らせたいルールや行動方針を記�
 ├── config.toml              # ユーザー共通設定（model・approval_policy・sandbox_mode・[mcp_servers] など）
 ├── <profile>.config.toml    # プロファイル別設定（--profile <name> で選択）
 ├── AGENTS.md                # ユーザー共通の指示（グローバル）
-├── AGENTS.override.md       # AGENTS.md を上書きするグローバル指示（存在すれば優先）
+├── AGENTS.override.md       # 存在する場合、AGENTS.md の代わりに読み込まれる（併読されない）
 ├── prompts/
 │   └── *.md                 # カスタムプロンプト（/prompts:<名前> で呼び出し。※非推奨、skills 推奨）
 ├── hooks.json               # ライフサイクルフック（config.toml 内 [hooks] でも可）
@@ -174,7 +174,7 @@ Instructions とは、AI Agent に守らせたいルールや行動方針を記�
 ```text
 [project]/
 ├── AGENTS.md               # プロジェクト指示（リポジトリルート）
-├── AGENTS.override.md      # AGENTS.md を上書きする指示（存在すれば優先）
+├── AGENTS.override.md      # 存在する場合、AGENTS.md の代わりに読み込まれる（併読されない）
 ├── .agents/
 │   └── skills/
 │       └── <skill-name>/SKILL.md  # プロジェクトスキル


### PR DESCRIPTION
- knowledge.md に Codex CLI のディレクトリ構成セクションを追加
  （~/.codex/ グローバル、.codex/ プロジェクト、AGENTS.md 解決順、
   config.toml 優先順位、[mcp_servers]、.agents/skills 規約など）
- install.sh が AGENTS.md を ~/.codex/AGENTS.md にも配置するよう対応
  （Codex は ~/AGENTS.md を参照しないため。~/.codex/ は削除せず AGENTS.md のみ差し替え）
- README.md に Codex 対応と配置先を明記

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DqomckS91VFcg72yP2jmNR