### PR TITLE
Generate GitHub Copilot instruction targets, add Windows launcher, and update install scripts/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Claude Code / GitHub Copilot / OpenAI Codex CLI 向けのグローバル設定リポジトリ。
 
 `install.sh` を実行すると、Claude Code / GitHub Copilot / OpenAI Codex CLI が同じ方針を読める場所へ設定を配置する。
-共通指示の正本は `AGENTS.md` とし、Claude Code は `~/.claude/CLAUDE.md` から import、GitHub Copilot は `~/.github/copilot-instructions.md`、OpenAI Codex CLI は `~/.codex/AGENTS.md` として同じ内容を参照する。
+共通指示の正本は `AGENTS.md` とし、Claude Code は `~/.claude/CLAUDE.md` から import、GitHub Copilot は `~/.github/copilot-instructions.md`、GitHub Copilot CLI は `AGENTS.md` から生成した `~/.copilot/copilot-instructions.md`、GitHub Copilot for VS Code は `~/.copilot/instructions/agents-global.instructions.md`、OpenAI Codex CLI は `~/.codex/AGENTS.md` として同じ内容を参照する。
 スキルは Claude Code 向けに `~/.claude/skills/`、Codex 向けに `~/.agents/skills/` へ配置する。
 
 ## 構成
@@ -13,7 +13,8 @@ AGENTS.md                 # グローバル共通指示（言語・トーン・�
 .github/
   copilot-instructions.md # GitHub Copilot 用の共通指示ミラー
 install.sh                # Linux / macOS / Git Bash 向けインストーラ
-install.ps1               # Windows PowerShell 向けインストーラ
+install.cmd               # Windows 向け起動ラッパー（ExecutionPolicy Bypass）
+install.ps1               # Windows PowerShell 向けインストーラ本体
 knowledge.md              # 設定体系のリファレンスメモ
 .claude/
   CLAUDE.md               # @../AGENTS.md を import
@@ -35,24 +36,38 @@ cd AgentsGlobalSettings
 sh install.sh
 ```
 
-Windows PowerShell では以下を実行する。
+Windows では以下を実行する。
+
+```bat
+.\install.cmd
+```
+
+PowerShell から `install.ps1` を直接実行して署名エラーが出る環境では、次のどちらかを使う。
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File .\install.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+```powershell
+Unblock-File .\install.ps1
+.\install.ps1
 ```
 
 ### Windows 対応
 
 - `install.sh` は POSIX sh 向けのため、Windows では Git Bash または WSL から実行する
-- PowerShell のみで実行したい場合は `install.ps1` を使う
-- `install.sh` と `install.ps1` は同じ配置先へ同じ設定をコピーする
+- PowerShell の実行ポリシーで未署名スクリプトがブロックされる場合があるため、Windows ではまず `install.cmd` を使う
+- PowerShell のみで実行したい場合は `powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1` を使う
+- `install.sh` / `install.cmd` / `install.ps1` は同じ配置先へ同じ設定をコピーする
 
 ### インストール時の挙動
 
 - 既存の `~/.claude/` はタイムスタンプ付きで `~/.settings-backup/` にバックアップされる
 - バックアップ後、`~/.claude/` は再作成され、このリポジトリ内の `.claude/` 配下がコピーされる
 - `AGENTS.md` は `~/AGENTS.md` にコピーされる
-- `.github/copilot-instructions.md` は GitHub Copilot 用に `~/.github/copilot-instructions.md` にコピーされる
+- GitHub Copilot 用の `~/.github/copilot-instructions.md` は `AGENTS.md` から生成される（既存があればバックアップ）
+- GitHub Copilot CLI 用の `~/.copilot/copilot-instructions.md` は `AGENTS.md` から生成される（既存があればバックアップ）
+- GitHub Copilot for VS Code 用の `~/.copilot/instructions/agents-global.instructions.md` は `AGENTS.md` から生成される（既存があればバックアップ）
 - `AGENTS.md` は Codex 用に `~/.codex/AGENTS.md` にもコピーされる（既存があればバックアップ。`~/.codex/` 内の `config.toml` や `auth.json` は削除・変更しない）
 - `.claude/skills/` 配下の各スキルは Codex 用に `~/.agents/skills/` にもコピーされる（`~/.agents/skills/` 全体はバックアップされるが削除はされず、このリポジトリと同名のスキルのみ置き換える）
 
@@ -61,6 +76,8 @@ powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```text
 ~/AGENTS.md
 ~/.github/copilot-instructions.md
+~/.copilot/copilot-instructions.md
+~/.copilot/instructions/agents-global.instructions.md
 ~/.codex/AGENTS.md
 ~/.agents/skills/
 ~/.claude/CLAUDE.md

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1" %*
+exit /b %ERRORLEVEL%

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,9 @@ $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ClaudeTarget = Join-Path $HOME ".claude"
 $CodexTarget = Join-Path $HOME ".codex"
 $AgentsSkillsTarget = Join-Path (Join-Path $HOME ".agents") "skills"
-$CopilotTarget = Join-Path (Join-Path $HOME ".github") "copilot-instructions.md"
+$CopilotWorkspaceTarget = Join-Path (Join-Path $HOME ".github") "copilot-instructions.md"
+$CopilotCliTarget = Join-Path (Join-Path $HOME ".copilot") "copilot-instructions.md"
+$CopilotVsCodeTarget = Join-Path (Join-Path (Join-Path $HOME ".copilot") "instructions") "agents-global.instructions.md"
 $BackupRoot = Join-Path $HOME ".settings-backup"
 $BackupDir = Join-Path $BackupRoot (Get-Date -Format "yyyyMMdd-HHmmss")
 
@@ -42,6 +44,43 @@ function Copy-DirectoryStrict {
   Copy-Item -LiteralPath $Source -Destination $Destination -Recurse -Force
 }
 
+function Write-CopilotInstructions {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination,
+    [Parameter(Mandatory = $false)][bool]$IncludeFrontmatter = $false
+  )
+
+  if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
+    throw "missing source file: $Source"
+  }
+
+  $parent = Split-Path -Parent $Destination
+  if ($parent) {
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  }
+
+  $header = @()
+  if ($IncludeFrontmatter) {
+    $header += @(
+      "---",
+      "applyTo: ""**""",
+      "---",
+      ""
+    )
+  }
+  $header += @(
+    "# GitHub Copilot instructions",
+    "",
+    "This file mirrors the shared global agent instructions used by Claude Code and OpenAI Codex.",
+    "",
+    "> Source of truth: ``AGENTS.md``",
+    ""
+  )
+  $body = Get-Content -LiteralPath $Source -Encoding UTF8
+  Set-Content -LiteralPath $Destination -Value ($header + $body) -Encoding UTF8
+}
+
 function Backup-Existing {
   param(
     [Parameter(Mandatory = $true)][string]$Source,
@@ -56,13 +95,16 @@ function Backup-Existing {
 }
 
 Backup-Existing $ClaudeTarget "claude"
-
 Remove-Item -LiteralPath $ClaudeTarget -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path $ClaudeTarget | Out-Null
 
 Copy-FileStrict (Join-Path $RootDir "AGENTS.md") (Join-Path $HOME "AGENTS.md")
-Backup-Existing $CopilotTarget "copilot-instructions.md"
-Copy-FileStrict (Join-Path (Join-Path $RootDir ".github") "copilot-instructions.md") $CopilotTarget
+Backup-Existing $CopilotWorkspaceTarget "github-copilot-instructions.md"
+Write-CopilotInstructions (Join-Path $RootDir "AGENTS.md") $CopilotWorkspaceTarget
+Backup-Existing $CopilotCliTarget "copilot-copilot-instructions.md"
+Write-CopilotInstructions (Join-Path $RootDir "AGENTS.md") $CopilotCliTarget
+Backup-Existing $CopilotVsCodeTarget "copilot-vscode-agents-global.instructions.md"
+Write-CopilotInstructions (Join-Path $RootDir "AGENTS.md") $CopilotVsCodeTarget $true
 Copy-FileStrict (Join-Path (Join-Path $RootDir ".claude") "CLAUDE.md") (Join-Path $ClaudeTarget "CLAUDE.md")
 Copy-FileStrict (Join-Path (Join-Path $RootDir ".claude") "settings.json") (Join-Path $ClaudeTarget "settings.json")
 
@@ -77,7 +119,9 @@ Copy-DirectoryStrict (Join-Path (Join-Path $RootDir ".claude") "hooks") (Join-Pa
 Copy-DirectoryStrict (Join-Path (Join-Path $RootDir ".claude") "skills") (Join-Path $ClaudeTarget "skills")
 
 Write-Host "Installed settings to $ClaudeTarget"
-Write-Host "Installed GitHub Copilot instructions to $CopilotTarget"
+Write-Host "Installed GitHub Copilot workspace instructions to $CopilotWorkspaceTarget"
+Write-Host "Installed GitHub Copilot CLI instructions to $CopilotCliTarget"
+Write-Host "Installed GitHub Copilot VS Code instructions to $CopilotVsCodeTarget"
 
 Backup-Existing (Join-Path $CodexTarget "AGENTS.md") "codex-AGENTS.md"
 Copy-FileStrict (Join-Path $RootDir "AGENTS.md") (Join-Path $CodexTarget "AGENTS.md")

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,9 @@ ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CLAUDE_TARGET="$HOME/.claude"
 CODEX_TARGET="$HOME/.codex"
 AGENTS_SKILLS_TARGET="$HOME/.agents/skills"
-COPILOT_TARGET="$HOME/.github/copilot-instructions.md"
+COPILOT_WORKSPACE_TARGET="$HOME/.github/copilot-instructions.md"
+COPILOT_CLI_TARGET="$HOME/.copilot/copilot-instructions.md"
+COPILOT_VSCODE_TARGET="$HOME/.copilot/instructions/agents-global.instructions.md"
 BACKUP_ROOT="$HOME/.settings-backup"
 BACKUP_DIR="$BACKUP_ROOT/$(date +%Y%m%d-%H%M%S)"
 
@@ -36,6 +38,30 @@ copy_dir() {
   cp -R "$src" "$dest"
 }
 
+write_copilot_instructions() {
+  src=$1
+  dest=$2
+  frontmatter=${3:-false}
+
+  if [ ! -f "$src" ]; then
+    printf 'missing source file: %s\n' "$src" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname -- "$dest")"
+  {
+    if [ "$frontmatter" = "true" ]; then
+      printf '%s\n' '---'
+      printf 'applyTo: "**"\n'
+      printf '%s\n\n' '---'
+    fi
+    printf '# GitHub Copilot instructions\n\n'
+    printf 'This file mirrors the shared global agent instructions used by Claude Code and OpenAI Codex.\n\n'
+    printf '> Source of truth: `AGENTS.md`\n\n'
+    cat "$src"
+  } > "$dest"
+}
+
 backup_existing() {
   src=$1
   name=$2
@@ -53,8 +79,12 @@ rm -rf "$CLAUDE_TARGET"
 mkdir -p "$CLAUDE_TARGET"
 
 copy_file "$ROOT_DIR/AGENTS.md" "$HOME/AGENTS.md"
-backup_existing "$COPILOT_TARGET" "copilot-instructions.md"
-copy_file "$ROOT_DIR/.github/copilot-instructions.md" "$COPILOT_TARGET"
+backup_existing "$COPILOT_WORKSPACE_TARGET" "github-copilot-instructions.md"
+write_copilot_instructions "$ROOT_DIR/AGENTS.md" "$COPILOT_WORKSPACE_TARGET"
+backup_existing "$COPILOT_CLI_TARGET" "copilot-copilot-instructions.md"
+write_copilot_instructions "$ROOT_DIR/AGENTS.md" "$COPILOT_CLI_TARGET"
+backup_existing "$COPILOT_VSCODE_TARGET" "copilot-vscode-agents-global.instructions.md"
+write_copilot_instructions "$ROOT_DIR/AGENTS.md" "$COPILOT_VSCODE_TARGET" true
 copy_file "$ROOT_DIR/.claude/CLAUDE.md" "$CLAUDE_TARGET/CLAUDE.md"
 copy_file "$ROOT_DIR/.claude/settings.json" "$CLAUDE_TARGET/settings.json"
 
@@ -68,7 +98,9 @@ copy_dir "$ROOT_DIR/.claude/hooks" "$CLAUDE_TARGET/hooks"
 copy_dir "$ROOT_DIR/.claude/skills" "$CLAUDE_TARGET/skills"
 
 printf 'Installed settings to %s\n' "$CLAUDE_TARGET"
-printf 'Installed GitHub Copilot instructions to %s\n' "$COPILOT_TARGET"
+printf 'Installed GitHub Copilot workspace instructions to %s\n' "$COPILOT_WORKSPACE_TARGET"
+printf 'Installed GitHub Copilot CLI instructions to %s\n' "$COPILOT_CLI_TARGET"
+printf 'Installed GitHub Copilot VS Code instructions to %s\n' "$COPILOT_VSCODE_TARGET"
 
 # OpenAI Codex CLI はグローバル指示を ~/.codex/AGENTS.md から読む（~/AGENTS.md は参照しない）。
 # 認証情報や config.toml を保持する ~/.codex/ は削除せず、AGENTS.md のみ差し替える。


### PR DESCRIPTION
### Motivation

- Unify the global `AGENTS.md` source-of-truth by generating Copilot-specific instruction files for different Copilot consumers instead of keeping a separate static mirror.
- Improve Windows install experience by adding a launcher that bypasses PowerShell execution policy friction and documenting recommended invocation.
- Ensure Copilot variants include an informative header and optional frontmatter for VS Code integration while keeping existing backup behavior.

### Description

- Updated `README.md` to document the new `install.cmd` launcher, Windows invocation examples, and the three Copilot-target paths (`~/.github/`, `~/.copilot/`, and `~/.copilot/instructions/`).
- Added `install.cmd` as a thin Windows wrapper that calls `install.ps1` with `-NoProfile -ExecutionPolicy Bypass`.
- Extended `install.ps1` and `install.sh` with `Write-CopilotInstructions` / `write_copilot_instructions` functions to generate Copilot instruction files from `AGENTS.md` for workspace Copilot, Copilot CLI, and Copilot for VS Code (the VS Code file receives YAML frontmatter).
- Retained existing backup logic and Claude/Codex install behavior while updating copy targets and install messages to reflect the new outputs.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a539eb72c44832ca25da76ec26407d5)