### PR TITLE
Add Copilot CLI/VSCode outputs, Codex agent TOML conversion, and Windows install wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Claude Code / GitHub Copilot / OpenAI Codex CLI 向けのグローバル設定リポジトリ。
 
 `install.sh` を実行すると、Claude Code / GitHub Copilot / OpenAI Codex CLI が同じ方針を読める場所へ設定を配置する。
-共通指示の正本は `AGENTS.md` とし、Claude Code は `~/.claude/CLAUDE.md` から import、GitHub Copilot は `~/.github/copilot-instructions.md`、OpenAI Codex CLI は `~/.codex/AGENTS.md` として同じ内容を参照する。
-スキルは Claude Code 向けに `~/.claude/skills/`、Codex 向けに `~/.agents/skills/` へ配置する。
+共通指示の正本は `AGENTS.md` とし、Claude Code は `~/.claude/CLAUDE.md` から import、GitHub Copilot は `~/.github/copilot-instructions.md`、GitHub Copilot CLI は `AGENTS.md` から生成した `~/.copilot/copilot-instructions.md`、GitHub Copilot for VS Code は `~/.copilot/instructions/agents-global.instructions.md`、OpenAI Codex CLI は `~/.codex/AGENTS.md` として同じ内容を参照する。
+スキルは Claude Code 向けに `~/.claude/skills/`、Codex 向けに `~/.agents/skills/` へ配置する。Sub Agent は Claude Code 向けに `~/.claude/agents/` へコピーし、Codex 向けには `.claude/agents/*.agent.md` から `~/.codex/agents/*.toml` を生成する。
 
 ## 構成
 
@@ -13,7 +13,8 @@ AGENTS.md                 # グローバル共通指示（言語・トーン・�
 .github/
   copilot-instructions.md # GitHub Copilot 用の共通指示ミラー
 install.sh                # Linux / macOS / Git Bash 向けインストーラ
-install.ps1               # Windows PowerShell 向けインストーラ
+install.cmd               # Windows 向け起動ラッパー（ExecutionPolicy Bypass）
+install.ps1               # Windows PowerShell 向けインストーラ本体
 knowledge.md              # 設定体系のリファレンスメモ
 .claude/
   CLAUDE.md               # @../AGENTS.md を import
@@ -35,25 +36,40 @@ cd AgentsGlobalSettings
 sh install.sh
 ```
 
-Windows PowerShell では以下を実行する。
+Windows では以下を実行する。
+
+```bat
+.\install.cmd
+```
+
+PowerShell から `install.ps1` を直接実行して署名エラーが出る環境では、次のどちらかを使う。
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File .\install.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+```powershell
+Unblock-File .\install.ps1
+.\install.ps1
 ```
 
 ### Windows 対応
 
 - `install.sh` は POSIX sh 向けのため、Windows では Git Bash または WSL から実行する
-- PowerShell のみで実行したい場合は `install.ps1` を使う
-- `install.sh` と `install.ps1` は同じ配置先へ同じ設定をコピーする
+- PowerShell の実行ポリシーで未署名スクリプトがブロックされる場合があるため、Windows ではまず `install.cmd` を使う
+- PowerShell のみで実行したい場合は `powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1` を使う
+- `install.sh` / `install.cmd` / `install.ps1` は同じ配置先へ同じ設定をコピーする
 
 ### インストール時の挙動
 
 - 既存の `~/.claude/` はタイムスタンプ付きで `~/.settings-backup/` にバックアップされる
 - バックアップ後、`~/.claude/` は再作成され、このリポジトリ内の `.claude/` 配下がコピーされる
 - `AGENTS.md` は `~/AGENTS.md` にコピーされる
-- `.github/copilot-instructions.md` は GitHub Copilot 用に `~/.github/copilot-instructions.md` にコピーされる
+- GitHub Copilot 用の `~/.github/copilot-instructions.md` は `AGENTS.md` から生成される（既存があればバックアップ）
+- GitHub Copilot CLI 用の `~/.copilot/copilot-instructions.md` は `AGENTS.md` から生成される（既存があればバックアップ）
+- GitHub Copilot for VS Code 用の `~/.copilot/instructions/agents-global.instructions.md` は `AGENTS.md` から生成される（既存があればバックアップ）
 - `AGENTS.md` は Codex 用に `~/.codex/AGENTS.md` にもコピーされる（既存があればバックアップ。`~/.codex/` 内の `config.toml` や `auth.json` は削除・変更しない）
+- `.claude/agents/*.agent.md` は Codex custom agents 用の TOML に変換され、`~/.codex/agents/*.toml` に生成される（既存があればバックアップ）
 - `.claude/skills/` 配下の各スキルは Codex 用に `~/.agents/skills/` にもコピーされる（`~/.agents/skills/` 全体はバックアップされるが削除はされず、このリポジトリと同名のスキルのみ置き換える）
 
 インストール後の主な配置先は以下のとおり。
@@ -61,7 +77,10 @@ powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```text
 ~/AGENTS.md
 ~/.github/copilot-instructions.md
+~/.copilot/copilot-instructions.md
+~/.copilot/instructions/agents-global.instructions.md
 ~/.codex/AGENTS.md
+~/.codex/agents/
 ~/.agents/skills/
 ~/.claude/CLAUDE.md
 ~/.claude/settings.json

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1" %*
+exit /b %ERRORLEVEL%

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,10 @@ $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ClaudeTarget = Join-Path $HOME ".claude"
 $CodexTarget = Join-Path $HOME ".codex"
 $AgentsSkillsTarget = Join-Path (Join-Path $HOME ".agents") "skills"
-$CopilotTarget = Join-Path (Join-Path $HOME ".github") "copilot-instructions.md"
+$CodexAgentsTarget = Join-Path $CodexTarget "agents"
+$CopilotWorkspaceTarget = Join-Path (Join-Path $HOME ".github") "copilot-instructions.md"
+$CopilotCliTarget = Join-Path (Join-Path $HOME ".copilot") "copilot-instructions.md"
+$CopilotVsCodeTarget = Join-Path (Join-Path (Join-Path $HOME ".copilot") "instructions") "agents-global.instructions.md"
 $BackupRoot = Join-Path $HOME ".settings-backup"
 $BackupDir = Join-Path $BackupRoot (Get-Date -Format "yyyyMMdd-HHmmss")
 
@@ -42,6 +45,127 @@ function Copy-DirectoryStrict {
   Copy-Item -LiteralPath $Source -Destination $Destination -Recurse -Force
 }
 
+function Write-CopilotInstructions {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination,
+    [Parameter(Mandatory = $false)][bool]$IncludeFrontmatter = $false
+  )
+
+  if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
+    throw "missing source file: $Source"
+  }
+
+  $parent = Split-Path -Parent $Destination
+  if ($parent) {
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  }
+
+  $header = @()
+  if ($IncludeFrontmatter) {
+    $header += @(
+      "---",
+      "applyTo: ""**""",
+      "---",
+      ""
+    )
+  }
+  $header += @(
+    "# GitHub Copilot instructions",
+    "",
+    "This file mirrors the shared global agent instructions used by Claude Code and OpenAI Codex.",
+    "",
+    "> Source of truth: ``AGENTS.md``",
+    ""
+  )
+  $body = Get-Content -LiteralPath $Source -Encoding UTF8
+  Set-Content -LiteralPath $Destination -Value ($header + $body) -Encoding UTF8
+}
+
+function ConvertTo-TomlBasicString {
+  param([Parameter(Mandatory = $true)][string]$Value)
+
+  return $Value.Replace('\', '\\').Replace('"', '\"')
+}
+
+function Get-AgentFrontmatterValue {
+  param(
+    [Parameter(Mandatory = $true)][string[]]$Lines,
+    [Parameter(Mandatory = $true)][string]$Key
+  )
+
+  if ($Lines.Count -eq 0 -or $Lines[0] -ne "---") {
+    return $null
+  }
+
+  for ($i = 1; $i -lt $Lines.Count; $i++) {
+    if ($Lines[$i] -eq "---") {
+      break
+    }
+    if ($Lines[$i] -match "^$([regex]::Escape($Key)):\s*(.*)$") {
+      return $Matches[1]
+    }
+  }
+
+  return $null
+}
+
+function Get-AgentBody {
+  param([Parameter(Mandatory = $true)][string[]]$Lines)
+
+  if ($Lines.Count -eq 0 -or $Lines[0] -ne "---") {
+    return $Lines
+  }
+
+  for ($i = 1; $i -lt $Lines.Count; $i++) {
+    if ($Lines[$i] -eq "---") {
+      if ($i + 1 -lt $Lines.Count) {
+        return $Lines[($i + 1)..($Lines.Count - 1)]
+      }
+      return @()
+    }
+  }
+
+  return $Lines
+}
+
+function Write-CodexAgent {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination
+  )
+
+  if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) {
+    throw "missing source file: $Source"
+  }
+
+  $lines = Get-Content -LiteralPath $Source -Encoding UTF8
+  $sourceLeaf = Split-Path -Leaf $Source
+  $fileBaseName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($sourceLeaf))
+  $agentName = Get-AgentFrontmatterValue $lines "name"
+  if (-not $agentName) {
+    $agentName = $fileBaseName
+  }
+  $description = Get-AgentFrontmatterValue $lines "description"
+  if (-not $description) {
+    $description = "Imported from Claude agent $fileBaseName."
+  }
+  $body = Get-AgentBody $lines
+
+  $parent = Split-Path -Parent $Destination
+  if ($parent) {
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  }
+
+  $content = @(
+    "name = `"$(ConvertTo-TomlBasicString $agentName)`"",
+    "description = `"$(ConvertTo-TomlBasicString $description)`"",
+    "developer_instructions = '''"
+  ) + $body + @("'''", "")
+
+  Set-Content -LiteralPath $Destination -Value $content -Encoding UTF8
+}
+
 function Backup-Existing {
   param(
     [Parameter(Mandatory = $true)][string]$Source,
@@ -56,13 +180,16 @@ function Backup-Existing {
 }
 
 Backup-Existing $ClaudeTarget "claude"
-
 Remove-Item -LiteralPath $ClaudeTarget -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path $ClaudeTarget | Out-Null
 
 Copy-FileStrict (Join-Path $RootDir "AGENTS.md") (Join-Path $HOME "AGENTS.md")
-Backup-Existing $CopilotTarget "copilot-instructions.md"
-Copy-FileStrict (Join-Path (Join-Path $RootDir ".github") "copilot-instructions.md") $CopilotTarget
+Backup-Existing $CopilotWorkspaceTarget "github-copilot-instructions.md"
+Write-CopilotInstructions (Join-Path $RootDir "AGENTS.md") $CopilotWorkspaceTarget
+Backup-Existing $CopilotCliTarget "copilot-copilot-instructions.md"
+Write-CopilotInstructions (Join-Path $RootDir "AGENTS.md") $CopilotCliTarget
+Backup-Existing $CopilotVsCodeTarget "copilot-vscode-agents-global.instructions.md"
+Write-CopilotInstructions (Join-Path $RootDir "AGENTS.md") $CopilotVsCodeTarget $true
 Copy-FileStrict (Join-Path (Join-Path $RootDir ".claude") "CLAUDE.md") (Join-Path $ClaudeTarget "CLAUDE.md")
 Copy-FileStrict (Join-Path (Join-Path $RootDir ".claude") "settings.json") (Join-Path $ClaudeTarget "settings.json")
 
@@ -77,12 +204,25 @@ Copy-DirectoryStrict (Join-Path (Join-Path $RootDir ".claude") "hooks") (Join-Pa
 Copy-DirectoryStrict (Join-Path (Join-Path $RootDir ".claude") "skills") (Join-Path $ClaudeTarget "skills")
 
 Write-Host "Installed settings to $ClaudeTarget"
-Write-Host "Installed GitHub Copilot instructions to $CopilotTarget"
+Write-Host "Installed GitHub Copilot workspace instructions to $CopilotWorkspaceTarget"
+Write-Host "Installed GitHub Copilot CLI instructions to $CopilotCliTarget"
+Write-Host "Installed GitHub Copilot VS Code instructions to $CopilotVsCodeTarget"
 
 Backup-Existing (Join-Path $CodexTarget "AGENTS.md") "codex-AGENTS.md"
 Copy-FileStrict (Join-Path $RootDir "AGENTS.md") (Join-Path $CodexTarget "AGENTS.md")
 
 Write-Host "Installed Codex instructions to $(Join-Path $CodexTarget "AGENTS.md")"
+
+Backup-Existing $CodexAgentsTarget "codex-agents"
+New-Item -ItemType Directory -Force -Path $CodexAgentsTarget | Out-Null
+$SourceAgents = Join-Path (Join-Path $RootDir ".claude") "agents"
+Get-ChildItem -LiteralPath $SourceAgents -Filter "*.agent.md" -File | ForEach-Object {
+  $AgentName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($_.Name))
+  $AgentTarget = Join-Path $CodexAgentsTarget "$AgentName.toml"
+  Write-CodexAgent $_.FullName $AgentTarget
+}
+
+Write-Host "Installed Codex agents to $CodexAgentsTarget"
 
 Backup-Existing $AgentsSkillsTarget "agents-skills"
 New-Item -ItemType Directory -Force -Path $AgentsSkillsTarget | Out-Null

--- a/install.ps1
+++ b/install.ps1
@@ -94,16 +94,21 @@ function Get-AgentFrontmatterValue {
     [Parameter(Mandatory = $true)][string]$Key
   )
 
-  if ($Lines.Count -eq 0 -or $Lines[0] -ne "---") {
+  if ($Lines.Count -eq 0 -or $Lines[0].TrimEnd("`r") -ne "---") {
     return $null
   }
 
   for ($i = 1; $i -lt $Lines.Count; $i++) {
-    if ($Lines[$i] -eq "---") {
+    $line = $Lines[$i].TrimEnd("`r")
+    if ($line -eq "---") {
       break
     }
-    if ($Lines[$i] -match "^$([regex]::Escape($Key)):\s*(.*)$") {
-      return $Matches[1]
+    if ($line -match "^$([regex]::Escape($Key)):\s*(.*)$") {
+      $value = $Matches[1].Trim()
+      if ($value -match '^"(.*)"$' -or $value -match "^'(.*)'$") {
+        return $Matches[1]
+      }
+      return $value
     }
   }
 
@@ -113,12 +118,12 @@ function Get-AgentFrontmatterValue {
 function Get-AgentBody {
   param([Parameter(Mandatory = $true)][string[]]$Lines)
 
-  if ($Lines.Count -eq 0 -or $Lines[0] -ne "---") {
+  if ($Lines.Count -eq 0 -or $Lines[0].TrimEnd("`r") -ne "---") {
     return $Lines
   }
 
   for ($i = 1; $i -lt $Lines.Count; $i++) {
-    if ($Lines[$i] -eq "---") {
+    if ($Lines[$i].TrimEnd("`r") -eq "---") {
       if ($i + 1 -lt $Lines.Count) {
         return $Lines[($i + 1)..($Lines.Count - 1)]
       }
@@ -139,7 +144,7 @@ function Write-CodexAgent {
     throw "missing source file: $Source"
   }
 
-  $lines = Get-Content -LiteralPath $Source -Encoding UTF8
+  $lines = @(Get-Content -LiteralPath $Source -Encoding UTF8)
   $sourceLeaf = Split-Path -Leaf $Source
   $fileBaseName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($sourceLeaf))
   $agentName = Get-AgentFrontmatterValue $lines "name"

--- a/install.sh
+++ b/install.sh
@@ -70,14 +70,30 @@ toml_escape_basic_string() {
 agent_frontmatter_value() {
   key=$1
   src=$2
-  awk -v key="$key" '
-    NR == 1 && $0 == "---" { in_frontmatter = 1; next }
-    in_frontmatter && $0 == "---" { exit }
+  awk -v key="$key" -v q="'" '
+    NR == 1 {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line == "---") {
+        in_frontmatter = 1
+        next
+      }
+      exit
+    }
     in_frontmatter {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line == "---") {
+        exit
+      }
       pattern = "^" key ":[[:space:]]*"
-      if ($0 ~ pattern) {
-        sub(pattern, "")
-        print
+      if (line ~ pattern) {
+        sub(pattern, "", line)
+        sub(/[[:space:]]*$/, "", line)
+        if ((line ~ /^"[^"]*"$/) || (line ~ "^" q "[^" q "]*" q "$")) {
+          line = substr(line, 2, length(line) - 2)
+        }
+        print line
         exit
       }
     }
@@ -87,10 +103,25 @@ agent_frontmatter_value() {
 write_agent_body() {
   src=$1
   awk '
-    NR == 1 && $0 == "---" { in_frontmatter = 1; next }
-    in_frontmatter && $0 == "---" { in_frontmatter = 0; in_body = 1; next }
-    in_body { print; next }
-    !in_frontmatter && NR != 1 { print }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+    }
+    NR == 1 {
+      if (line == "---") {
+        in_frontmatter = 1
+        next
+      }
+      print line
+      next
+    }
+    in_frontmatter {
+      if (line == "---") {
+        in_frontmatter = 0
+      }
+      next
+    }
+    { print line }
   ' "$src"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,10 @@ ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CLAUDE_TARGET="$HOME/.claude"
 CODEX_TARGET="$HOME/.codex"
 AGENTS_SKILLS_TARGET="$HOME/.agents/skills"
-COPILOT_TARGET="$HOME/.github/copilot-instructions.md"
+CODEX_AGENTS_TARGET="$HOME/.codex/agents"
+COPILOT_WORKSPACE_TARGET="$HOME/.github/copilot-instructions.md"
+COPILOT_CLI_TARGET="$HOME/.copilot/copilot-instructions.md"
+COPILOT_VSCODE_TARGET="$HOME/.copilot/instructions/agents-global.instructions.md"
 BACKUP_ROOT="$HOME/.settings-backup"
 BACKUP_DIR="$BACKUP_ROOT/$(date +%Y%m%d-%H%M%S)"
 
@@ -36,6 +39,91 @@ copy_dir() {
   cp -R "$src" "$dest"
 }
 
+write_copilot_instructions() {
+  src=$1
+  dest=$2
+  frontmatter=${3:-false}
+
+  if [ ! -f "$src" ]; then
+    printf 'missing source file: %s\n' "$src" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname -- "$dest")"
+  {
+    if [ "$frontmatter" = "true" ]; then
+      printf '%s\n' '---'
+      printf 'applyTo: "**"\n'
+      printf '%s\n\n' '---'
+    fi
+    printf '# GitHub Copilot instructions\n\n'
+    printf 'This file mirrors the shared global agent instructions used by Claude Code and OpenAI Codex.\n\n'
+    printf '> Source of truth: `AGENTS.md`\n\n'
+    cat "$src"
+  } > "$dest"
+}
+
+toml_escape_basic_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+agent_frontmatter_value() {
+  key=$1
+  src=$2
+  awk -v key="$key" '
+    NR == 1 && $0 == "---" { in_frontmatter = 1; next }
+    in_frontmatter && $0 == "---" { exit }
+    in_frontmatter {
+      pattern = "^" key ":[[:space:]]*"
+      if ($0 ~ pattern) {
+        sub(pattern, "")
+        print
+        exit
+      }
+    }
+  ' "$src"
+}
+
+write_agent_body() {
+  src=$1
+  awk '
+    NR == 1 && $0 == "---" { in_frontmatter = 1; next }
+    in_frontmatter && $0 == "---" { in_frontmatter = 0; in_body = 1; next }
+    in_body { print; next }
+    !in_frontmatter && NR != 1 { print }
+  ' "$src"
+}
+
+write_codex_agent() {
+  src=$1
+  dest=$2
+
+  if [ ! -f "$src" ]; then
+    printf 'missing source file: %s\n' "$src" >&2
+    exit 1
+  fi
+
+  agent_file=$(basename -- "$src")
+  agent_name=${agent_file%.agent.md}
+  frontmatter_name=$(agent_frontmatter_value name "$src")
+  if [ -n "$frontmatter_name" ]; then
+    agent_name=$frontmatter_name
+  fi
+  description=$(agent_frontmatter_value description "$src")
+  if [ -z "$description" ]; then
+    description="Imported from Claude agent ${agent_file%.agent.md}."
+  fi
+
+  mkdir -p "$(dirname -- "$dest")"
+  {
+    printf 'name = "%s"\n' "$(toml_escape_basic_string "$agent_name")"
+    printf 'description = "%s"\n' "$(toml_escape_basic_string "$description")"
+    printf "developer_instructions = '''\n"
+    write_agent_body "$src"
+    printf "'''\n"
+  } > "$dest"
+}
+
 backup_existing() {
   src=$1
   name=$2
@@ -53,8 +141,12 @@ rm -rf "$CLAUDE_TARGET"
 mkdir -p "$CLAUDE_TARGET"
 
 copy_file "$ROOT_DIR/AGENTS.md" "$HOME/AGENTS.md"
-backup_existing "$COPILOT_TARGET" "copilot-instructions.md"
-copy_file "$ROOT_DIR/.github/copilot-instructions.md" "$COPILOT_TARGET"
+backup_existing "$COPILOT_WORKSPACE_TARGET" "github-copilot-instructions.md"
+write_copilot_instructions "$ROOT_DIR/AGENTS.md" "$COPILOT_WORKSPACE_TARGET"
+backup_existing "$COPILOT_CLI_TARGET" "copilot-copilot-instructions.md"
+write_copilot_instructions "$ROOT_DIR/AGENTS.md" "$COPILOT_CLI_TARGET"
+backup_existing "$COPILOT_VSCODE_TARGET" "copilot-vscode-agents-global.instructions.md"
+write_copilot_instructions "$ROOT_DIR/AGENTS.md" "$COPILOT_VSCODE_TARGET" true
 copy_file "$ROOT_DIR/.claude/CLAUDE.md" "$CLAUDE_TARGET/CLAUDE.md"
 copy_file "$ROOT_DIR/.claude/settings.json" "$CLAUDE_TARGET/settings.json"
 
@@ -68,7 +160,9 @@ copy_dir "$ROOT_DIR/.claude/hooks" "$CLAUDE_TARGET/hooks"
 copy_dir "$ROOT_DIR/.claude/skills" "$CLAUDE_TARGET/skills"
 
 printf 'Installed settings to %s\n' "$CLAUDE_TARGET"
-printf 'Installed GitHub Copilot instructions to %s\n' "$COPILOT_TARGET"
+printf 'Installed GitHub Copilot workspace instructions to %s\n' "$COPILOT_WORKSPACE_TARGET"
+printf 'Installed GitHub Copilot CLI instructions to %s\n' "$COPILOT_CLI_TARGET"
+printf 'Installed GitHub Copilot VS Code instructions to %s\n' "$COPILOT_VSCODE_TARGET"
 
 # OpenAI Codex CLI はグローバル指示を ~/.codex/AGENTS.md から読む（~/AGENTS.md は参照しない）。
 # 認証情報や config.toml を保持する ~/.codex/ は削除せず、AGENTS.md のみ差し替える。
@@ -76,6 +170,17 @@ backup_existing "$CODEX_TARGET/AGENTS.md" "codex-AGENTS.md"
 copy_file "$ROOT_DIR/AGENTS.md" "$CODEX_TARGET/AGENTS.md"
 
 printf 'Installed Codex instructions to %s/AGENTS.md\n' "$CODEX_TARGET"
+
+backup_existing "$CODEX_AGENTS_TARGET" "codex-agents"
+mkdir -p "$CODEX_AGENTS_TARGET"
+for agent_file in "$ROOT_DIR/.claude/agents"/*.agent.md; do
+  [ -f "$agent_file" ] || continue
+  agent_name=$(basename -- "$agent_file")
+  agent_name=${agent_name%.agent.md}
+  write_codex_agent "$agent_file" "$CODEX_AGENTS_TARGET/$agent_name.toml"
+done
+
+printf 'Installed Codex agents to %s\n' "$CODEX_AGENTS_TARGET"
 
 # Codex は Agent Skills を ~/.agents/skills から読む（.agents/skills 規約）。
 # ~/.agents/skills は他ツールと共有され得るため全体は削除せず、


### PR DESCRIPTION
### Motivation

- Expand installer to produce instruction files for multiple Copilot targets and to better support Windows execution policies. 
- Enable reuse of Claude custom agents in OpenAI Codex by converting `.agent.md` files into simple TOML agent definitions. 
- Update documentation to reflect the new install targets and Windows usage patterns. 

### Description

- Added `install.cmd` as a Windows wrapper that launches PowerShell with `-ExecutionPolicy Bypass` and forwards arguments. 
- Extended `install.ps1` and `install.sh` to generate three Copilot targets from `AGENTS.md`: workspace (`~/.github/copilot-instructions.md`), CLI (`~/.copilot/copilot-instructions.md`), and VS Code (`~/.copilot/instructions/agents-global.instructions.md`), with an option to include frontmatter. 
- Implemented conversion of `.claude/agents/*.agent.md` into `~/.codex/agents/*.toml` by extracting frontmatter `name`/`description` and embedding the agent body into a `developer_instructions` TOML string in both `install.ps1` (`Write-CodexAgent`) and `install.sh` (`write_codex_agent`). 
- Updated `README.md` to document the new targets, Windows usage (`install.cmd` and `powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1`), backup behavior, and the Codex agents output. 

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a539eb72c44832ca25da76ec26407d5)