### PR TITLE
Fix unresolved installer conflict markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ Claude Code / GitHub Copilot / OpenAI Codex CLI 向けのグローバル設定�
 
 `install.sh` を実行すると、Claude Code / GitHub Copilot / OpenAI Codex CLI が同じ方針を読める場所へ設定を配置する。
 共通指示の正本は `AGENTS.md` とし、Claude Code は `~/.claude/CLAUDE.md` から import、GitHub Copilot は `~/.github/copilot-instructions.md`、GitHub Copilot CLI は `AGENTS.md` から生成した `~/.copilot/copilot-instructions.md`、GitHub Copilot for VS Code は `~/.copilot/instructions/agents-global.instructions.md`、OpenAI Codex CLI は `~/.codex/AGENTS.md` として同じ内容を参照する。
-<<<<<<< 6wpy5e-codex/reviewconflict
 スキルは Claude Code 向けに `~/.claude/skills/`、Codex 向けに `~/.agents/skills/` へ配置する。Sub Agent は Claude Code 向けに `~/.claude/agents/` へコピーし、Codex 向けには `.claude/agents/*.agent.md` から `~/.codex/agents/*.toml` を生成する。
-=======
-スキルは Claude Code 向けに `~/.claude/skills/`、Codex 向けに `~/.agents/skills/` へ配置する。
->>>>>>> master
 
 ## 構成
 

--- a/install.ps1
+++ b/install.ps1
@@ -4,10 +4,7 @@ $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ClaudeTarget = Join-Path $HOME ".claude"
 $CodexTarget = Join-Path $HOME ".codex"
 $AgentsSkillsTarget = Join-Path (Join-Path $HOME ".agents") "skills"
-<<<<<<< 6wpy5e-codex/reviewconflict
 $CodexAgentsTarget = Join-Path $CodexTarget "agents"
-=======
->>>>>>> master
 $CopilotWorkspaceTarget = Join-Path (Join-Path $HOME ".github") "copilot-instructions.md"
 $CopilotCliTarget = Join-Path (Join-Path $HOME ".copilot") "copilot-instructions.md"
 $CopilotVsCodeTarget = Join-Path (Join-Path (Join-Path $HOME ".copilot") "instructions") "agents-global.instructions.md"

--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,7 @@ ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CLAUDE_TARGET="$HOME/.claude"
 CODEX_TARGET="$HOME/.codex"
 AGENTS_SKILLS_TARGET="$HOME/.agents/skills"
-<<<<<<< 6wpy5e-codex/reviewconflict
 CODEX_AGENTS_TARGET="$HOME/.codex/agents"
-=======
->>>>>>> master
 COPILOT_WORKSPACE_TARGET="$HOME/.github/copilot-instructions.md"
 COPILOT_CLI_TARGET="$HOME/.copilot/copilot-instructions.md"
 COPILOT_VSCODE_TARGET="$HOME/.copilot/instructions/agents-global.instructions.md"


### PR DESCRIPTION
### Motivation
- The Windows `install.ps1` contained leftover merge conflict markers which caused PowerShell parser errors when run via `install.cmd`.
- The POSIX `install.sh` and `README.md` also contained the same unresolved markers, making the installers and documentation inconsistent.

### Description
- Remove literal merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) from `install.ps1`, `install.sh`, and `README.md` so the files parse correctly.
- Restore the Codex agents target variable as a normal definition (`$CodexAgentsTarget` / `CODEX_AGENTS_TARGET`) so agent TOML generation works.
- Preserve the Codex agent/skill generation logic that converts `.claude/agents/*.agent.md` into `~/.codex/agents/*.toml` and copies skills to `~/.agents/skills/`.
- Commit the cleaned files and prepare the repository so `install.cmd` / `install.ps1` no longer fail on Windows due to parser errors.

### Testing
- Ran `git diff --check` to ensure no leftover conflict markers, which passed.
- Performed a shell syntax check with `HOME=$(mktemp -d) sh -n install.sh` and executed `HOME=$(mktemp -d) sh install.sh`, both succeeded and produced the expected files under the temporary `HOME`.
- PowerShell could not be executed in the Linux container (no `pwsh`/`powershell`), so Windows script execution was not run here, but the PowerShell parser error reported by the user (caused by marker lines) has been removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562406aa7c832c926114fe9ab0488d)