### PR TITLE
Resolve merge conflicts and harden install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ Claude Code / GitHub Copilot / OpenAI Codex CLI 向けのグローバル設定�
 
 `install.sh` を実行すると、Claude Code / GitHub Copilot / OpenAI Codex CLI が同じ方針を読める場所へ設定を配置する。
 共通指示の正本は `AGENTS.md` とし、Claude Code は `~/.claude/CLAUDE.md` から import、GitHub Copilot は `~/.github/copilot-instructions.md`、GitHub Copilot CLI は `AGENTS.md` から生成した `~/.copilot/copilot-instructions.md`、GitHub Copilot for VS Code は `~/.copilot/instructions/agents-global.instructions.md`、OpenAI Codex CLI は `~/.codex/AGENTS.md` として同じ内容を参照する。
-<<<<<<< 6wpy5e-codex/reviewconflict
 スキルは Claude Code 向けに `~/.claude/skills/`、Codex 向けに `~/.agents/skills/` へ配置する。Sub Agent は Claude Code 向けに `~/.claude/agents/` へコピーし、Codex 向けには `.claude/agents/*.agent.md` から `~/.codex/agents/*.toml` を生成する。
-=======
-スキルは Claude Code 向けに `~/.claude/skills/`、Codex 向けに `~/.agents/skills/` へ配置する。
->>>>>>> master
 
 ## 構成
 

--- a/install.ps1
+++ b/install.ps1
@@ -4,10 +4,7 @@ $RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ClaudeTarget = Join-Path $HOME ".claude"
 $CodexTarget = Join-Path $HOME ".codex"
 $AgentsSkillsTarget = Join-Path (Join-Path $HOME ".agents") "skills"
-<<<<<<< 6wpy5e-codex/reviewconflict
 $CodexAgentsTarget = Join-Path $CodexTarget "agents"
-=======
->>>>>>> master
 $CopilotWorkspaceTarget = Join-Path (Join-Path $HOME ".github") "copilot-instructions.md"
 $CopilotCliTarget = Join-Path (Join-Path $HOME ".copilot") "copilot-instructions.md"
 $CopilotVsCodeTarget = Join-Path (Join-Path (Join-Path $HOME ".copilot") "instructions") "agents-global.instructions.md"
@@ -93,7 +90,7 @@ function ConvertTo-TomlBasicString {
 
 function Get-AgentFrontmatterValue {
   param(
-    [Parameter(Mandatory = $true)][string[]]$Lines,
+    [Parameter(Mandatory = $true)][AllowEmptyCollection()][AllowEmptyString()][string[]]$Lines,
     [Parameter(Mandatory = $true)][string]$Key
   )
 
@@ -119,7 +116,7 @@ function Get-AgentFrontmatterValue {
 }
 
 function Get-AgentBody {
-  param([Parameter(Mandatory = $true)][string[]]$Lines)
+  param([Parameter(Mandatory = $true)][AllowEmptyCollection()][AllowEmptyString()][string[]]$Lines)
 
   if ($Lines.Count -eq 0 -or $Lines[0].TrimEnd("`r") -ne "---") {
     return $Lines
@@ -150,15 +147,15 @@ function Write-CodexAgent {
   $lines = @(Get-Content -LiteralPath $Source -Encoding UTF8)
   $sourceLeaf = Split-Path -Leaf $Source
   $fileBaseName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($sourceLeaf))
-  $agentName = Get-AgentFrontmatterValue $lines "name"
+  $agentName = Get-AgentFrontmatterValue -Lines $lines -Key "name"
   if (-not $agentName) {
     $agentName = $fileBaseName
   }
-  $description = Get-AgentFrontmatterValue $lines "description"
+  $description = Get-AgentFrontmatterValue -Lines $lines -Key "description"
   if (-not $description) {
     $description = "Imported from Claude agent $fileBaseName."
   }
-  $body = Get-AgentBody $lines
+  $body = Get-AgentBody -Lines $lines
 
   $parent = Split-Path -Parent $Destination
   if ($parent) {
@@ -227,7 +224,7 @@ $SourceAgents = Join-Path (Join-Path $RootDir ".claude") "agents"
 Get-ChildItem -LiteralPath $SourceAgents -Filter "*.agent.md" -File | ForEach-Object {
   $AgentName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetFileNameWithoutExtension($_.Name))
   $AgentTarget = Join-Path $CodexAgentsTarget "$AgentName.toml"
-  Write-CodexAgent $_.FullName $AgentTarget
+  Write-CodexAgent -Source $_.FullName -Destination $AgentTarget
 }
 
 Write-Host "Installed Codex agents to $CodexAgentsTarget"

--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,7 @@ ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CLAUDE_TARGET="$HOME/.claude"
 CODEX_TARGET="$HOME/.codex"
 AGENTS_SKILLS_TARGET="$HOME/.agents/skills"
-<<<<<<< 6wpy5e-codex/reviewconflict
 CODEX_AGENTS_TARGET="$HOME/.codex/agents"
-=======
->>>>>>> master
 COPILOT_WORKSPACE_TARGET="$HOME/.github/copilot-instructions.md"
 COPILOT_CLI_TARGET="$HOME/.copilot/copilot-instructions.md"
 COPILOT_VSCODE_TARGET="$HOME/.copilot/instructions/agents-global.instructions.md"


### PR DESCRIPTION
### Motivation

- Remove leftover merge conflict markers and consolidate intended content in the README and installer scripts. 
- Improve robustness of the PowerShell installer when parsing agent files and calling helper functions to avoid runtime errors on empty inputs.

### Description

- Removed merge conflict markers and reconciled wording in `README.md` to restore the intended documentation lines. 
- Cleaned up conflict remnants in `install.sh` and `install.ps1` and ensured installation target variables are defined consistently. 
- Hardened PowerShell parsing functions by allowing empty collections/strings via `AllowEmptyCollection()` and `AllowEmptyString()` on `Get-AgentFrontmatterValue` and `Get-AgentBody`, and switched to named parameter invocation for clarity in `Write-CodexAgent` and frontmatter/body calls. 
- Kept existing behavior of converting Claude agents to Codex TOML files and copying skills and instruction files while improving parameter handling and call sites.

### Testing

- Ran `shellcheck` against `install.sh` to validate shell script style and syntax, which reported no critical issues. 
- Ran `PSScriptAnalyzer` against `install.ps1` to validate PowerShell script quality, which reported no critical issues. 
- No new unit tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562406aa7c832c926114fe9ab0488d)